### PR TITLE
"Enhanced" by making it overlay only

### DIFF
--- a/noisy/jquery.noisy.js
+++ b/noisy/jquery.noisy.js
@@ -2,6 +2,7 @@
 (function($){
 	// This function adds noise to the background-color attribute of an element
 	$.fn.noisy = function(options) {
+		
 		return this.each(function() {
 	 		var canvas = document.createElement('canvas'),
 	 		    ctx = canvas.getContext("2d");
@@ -33,12 +34,10 @@
 	 			imgData.data[index+2] = options.monochromatic ? randColorChannel : rand(0, 255);    // blue
 	 			imgData.data[index+3] = rand(0, 255 * options.maxNoiseOpacity);                     // alpha
 	 		}
-	 		
 	 		ctx.putImageData(imgData, 0, 0);
-	 		$(this).css('background', 'url(' + canvas.toDataURL('image/png') + ')' + options.backgroundColor);
+	 		$(this).css('background-image', 'url(' + canvas.toDataURL('image/png') + ')' );
 		});
 	};
-	
 	$.fn.noisy.defaults = {
 		// How many percent of the image that is filled with noise, 
 		//   represented by a number between 0 and 1 inclusive
@@ -47,15 +46,9 @@
 		// The width and height of the background image in pixels
 		tileSize:           200,
 		
-		// An empty string is transparent
-		backgroundColor:    '',
-		
 		// The maximum noise particle opacity,
 		//   represented by a number between 0 and 1 inclusive
 		maxNoiseOpacity:    0.08,
-		
-		// A string linking to the image used if there's no canvas support
-		fallbackImage:      '',
 		
 		// Specifies wheter the particles are grayscale or colorful
 		monochromatic:      false


### PR DESCRIPTION
Saw your awesome plugin.

I was having trouble where I already had elements specified in CSS in different colors and I just wanted to add noise to them. I didn't want to have to look up (or maintain) colors listed in two places, so I added a feature to this (by stripping out the color feature) which makes the noise only overlay whatever was already there.

Naturally this makes the fallback image irrelevant, since the fallback is just the solid, noise-free color.

Welcome to pull if you'd like a 'simple' version that's only meant to overlay existing elements.
