### PR TITLE
Try setting / removing localStorage value

### DIFF
--- a/jquery/jquery.noisy.js
+++ b/jquery/jquery.noisy.js
@@ -6,6 +6,8 @@
 		
 		try {
 			localStorageSupported = true;
+			localStorage.setItem("test", "");
+			localStorage.removeItem("test");
 			cachedUri = localStorage.getItem(window.JSON.stringify(options));
 		} catch(e) {
 			localStorageSupported = false;


### PR DESCRIPTION
Safari in iOS will throw a QUOTA_EXCEEDED_ERR when the client attempts to access localStorage while Private Browsing is turned on. 

Simply wrapping the getItem method in a try block does not fix the problem. This commit solves the issue by adding a call to setItem within the try block. removeItem just keeps the code clean.
