### PR TITLE
Include jQuery in bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,6 @@
   "version": "0.0.1",
   "main": "./jquery/jquery.noisy.js",
   "dependencies": {
+    "jquery": "^2.1.3"
   }
 }


### PR DESCRIPTION
Hi,

I've added jQuery to the bower dependencies because when you try to build your project with grunt-bower-concat Noisy get's concatenated before jQuery and this will result in errors.

[Here's some more info](https://github.com/sapegin/grunt-bower-concat#dependencies) on how to fix that without having the dependency listed.
